### PR TITLE
fixed KMunicate legend position in gallery.Rmd

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,8 +31,8 @@ jobs:
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
           - {os: ubuntu-latest,   r: 'oldrel-2'}
-          - {os: ubuntu-latest,   r: 'oldrel-3'}
-          - {os: ubuntu-latest,   r: 'oldrel-4'}
+          # - {os: ubuntu-latest,   r: 'oldrel-3'}
+          # - {os: ubuntu-latest,   r: 'oldrel-4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,4 +53,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/scale_ggsurvfit.R
+++ b/R/scale_ggsurvfit.R
@@ -7,6 +7,8 @@
 #' - `scale_y_continuous(expand = c(0.025, 0), limits = c(0, 1), label = scales::label_percent())`.
 #' - `scale_x_continuous(expand = c(0.015, 0), n.breaks = 8)`
 #'
+#' *NOTE*: The y-axis limits are only set for survival curves.
+#'
 #' If you use this function, you **must** include **all** scale specifications
 #' that would appear in `scale_x_continuous()` or `scale_y_continuous()`.
 #' For example, it's common you'll need to specify the x-axis break points.

--- a/ggsurvfit.Rproj
+++ b/ggsurvfit.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: bc923b98-5bad-45ab-b348-e227eecb86bc
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/man/scale_ggsurvfit.Rd
+++ b/man/scale_ggsurvfit.Rd
@@ -22,6 +22,8 @@ This scale applies modifications often seen in these figures.
 \item \code{scale_x_continuous(expand = c(0.015, 0), n.breaks = 8)}
 }
 
+\emph{NOTE}: The y-axis limits are only set for survival curves.
+
 If you use this function, you \strong{must} include \strong{all} scale specifications
 that would appear in \code{scale_x_continuous()} or \code{scale_y_continuous()}.
 For example, it's common you'll need to specify the x-axis break points.

--- a/tests/testthat/test-ggsurvfit.R
+++ b/tests/testthat/test-ggsurvfit.R
@@ -193,3 +193,20 @@ test_that("ggsurvfit() works with geoms with new data", {
   vdiffr::expect_doppelganger("sf2-ggsurvfit_new_data_geom1", p1)
   vdiffr::expect_doppelganger("sf2-ggsurvfit_new_data_geom2", p2)
 })
+
+test_that("KMunicate theme is working and reproducible", {
+
+  #plot from the documentation
+  p <- survfit2(Surv(time, status) ~ surg, data = df_colon) %>%
+    ggsurvfit(linetype_aes = TRUE) +
+    add_confidence_interval() +
+    add_risktable(
+      risktable_stats = c("n.risk", "cum.censor", "cum.event")
+    ) +
+    theme_ggsurvfit_KMunicate() +
+    scale_y_continuous(limits = c(0, 1)) +
+    scale_x_continuous(expand = c(0.02, 0)) +
+    theme(legend.position="inside", legend.position.inside = c(0.85, 0.85))
+  vdiffr::expect_doppelganger("vignette-ggsurvfit-KMunicate", p)
+})
+

--- a/tests/testthat/test-ggsurvfit.R
+++ b/tests/testthat/test-ggsurvfit.R
@@ -55,15 +55,6 @@ test_that("ggsurvfit() works", {
   vdiffr::expect_doppelganger("sf2-ggsurvfit_linetype", lst_survfit2_linetype[[1]])
   vdiffr::expect_doppelganger("sf3-ggsurvfit_linetype", lst_survfit2_linetype[[2]])
 
-  expect_error(
-    lst_survfit_KMunicate <-
-      list(sf1, sf2, sf3) %>%
-      lapply(function(x) ggsurvfit(x, theme = theme_ggsurvfit_KMunicate())),
-    NA
-  )
-  vdiffr::expect_doppelganger("sf1-ggsurvfit-KMunicate", lst_survfit_KMunicate[[1]])
-  vdiffr::expect_doppelganger("sf2-ggsurvfit-KMunicate", lst_survfit_KMunicate[[2]])
-  vdiffr::expect_doppelganger("sf3-ggsurvfit-KMunicate", lst_survfit_KMunicate[[3]])
 
   # test that the variable names are stripped when using transformations
   vdiffr::expect_doppelganger(
@@ -195,6 +186,16 @@ test_that("ggsurvfit() works with geoms with new data", {
 })
 
 test_that("KMunicate theme is working and reproducible", {
+
+  expect_no_error(
+    lst_survfit_KMunicate <-
+      list(sf1, sf2, sf3) %>%
+      lapply(function(x) ggsurvfit(x, theme = theme_ggsurvfit_KMunicate()))
+  )
+
+  vdiffr::expect_doppelganger("sf1-ggsurvfit-KMunicate", lst_survfit_KMunicate[[1]])
+  vdiffr::expect_doppelganger("sf2-ggsurvfit-KMunicate", lst_survfit_KMunicate[[2]])
+  vdiffr::expect_doppelganger("sf3-ggsurvfit-KMunicate", lst_survfit_KMunicate[[3]])
 
   #plot from the documentation
   p <- survfit2(Surv(time, status) ~ surg, data = df_colon) %>%

--- a/vignettes/articles/gallery.Rmd
+++ b/vignettes/articles/gallery.Rmd
@@ -317,7 +317,7 @@ survfit2(Surv(time, status) ~ surg, data = df_colon) %>%
   theme_ggsurvfit_KMunicate() +
   scale_y_continuous(limits = c(0, 1)) +
   scale_x_continuous(expand = c(0.02, 0)) +
-  theme(legend.position.inside = c(0.85, 0.85))
+  theme(legend.position="inside", legend.position.inside = c(0.85, 0.85))
 ```
 
 ## Swap Line Type & Color Aesthetics


### PR DESCRIPTION
Hi,

As you can see in https://www.danieldsjoberg.com/ggsurvfit/articles/gallery.html#kmunicate, the legend is not inside the plot as it should be.

This is because the theme lacks `legend.position="inside"`.

This very minor PR should fix it.

closes #233

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark as complete) 

- [x] Ensure all package dependencies are installed by running `renv::install()`
- [x] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [x] If a new function was added, function included in `_pkgdown.yml`
- [x] If a bug was fixed, a unit test was added for the bug check
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Overall code coverage remains >99.5%. Review coverage with `withr::with_envvar(list(CI = TRUE), code = devtools::test_coverage())`. Begin in a fresh R session without any packages loaded. 
- [x] R CMD Check runs without errors, warnings, and notes
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# ggsurvfit (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [x] Increment the version number using `usethis::use_version(which = "dev")` 
- [x] Run `usethis::use_spell_check()` again
- [x] Approve Pull Request
- [x] Merge the PR. Please use "Squash and merge".

