### PR TITLE
update documentation and example for ggsurvfit based on #216

### DIFF
--- a/R/scale_ggsurvfit.R
+++ b/R/scale_ggsurvfit.R
@@ -36,6 +36,19 @@
 #' # specify additional scales
 #' ggsurvfit +
 #'   scale_ggsurvfit(x_scales = list(breaks = seq(0, 8, by = 2)))
+#' #'
+#' @details
+#' Special case: in the risk table, large numbers (with more than 4 digits) may not
+#' be shown completely, with some digits truncated outside the plot region.
+#' To remedy this, consider adjusting the expand size:
+#'
+#' ```r
+#' scale_ggsurvfit(x_scales = list(expand = c(0.05, 0)))
+#' ```
+#'
+#' This can modify the position of numbers in the risk table
+#' and make them all fit in the plot region. The scale of the `expand` argument differs by cases.
+#'
 #' @inherit ggsurvfit seealso
 scale_ggsurvfit <- function(x_scales = list(), y_scales = list()){
   scale_ggsurvfit_empty_list <- list()

--- a/R/scale_ggsurvfit.R
+++ b/R/scale_ggsurvfit.R
@@ -23,20 +23,6 @@
 #' @return a ggplot2 figure
 #' @export
 #'
-#' @rdname scale_ggsurvfit
-#' @examples
-#' ggsurvfit <-
-#'   survfit2(Surv(time, status) ~ surg, data = df_colon) %>%
-#'   ggsurvfit(linewidth = 1) +
-#'   add_confidence_interval()
-#'
-#' # use the function defaults
-#' ggsurvfit + scale_ggsurvfit()
-#'
-#' # specify additional scales
-#' ggsurvfit +
-#'   scale_ggsurvfit(x_scales = list(breaks = seq(0, 8, by = 2)))
-#' #'
 #' @details
 #' Special case: in the risk table, large numbers (with more than 4 digits) may not
 #' be shown completely, with some digits truncated outside the plot region.
@@ -50,6 +36,18 @@
 #' and make them all fit in the plot region. The scale of the `expand` argument differs by cases.
 #'
 #' @inherit ggsurvfit seealso
+#' @examples
+#' ggsurvfit <-
+#'   survfit2(Surv(time, status) ~ surg, data = df_colon) %>%
+#'   ggsurvfit(linewidth = 1) +
+#'   add_confidence_interval()
+#'
+#' # use the function defaults
+#' ggsurvfit + scale_ggsurvfit()
+#'
+#' # specify additional scales
+#' ggsurvfit +
+#'   scale_ggsurvfit(x_scales = list(breaks = seq(0, 8, by = 2)))
 scale_ggsurvfit <- function(x_scales = list(), y_scales = list()){
   scale_ggsurvfit_empty_list <- list()
   structure(scale_ggsurvfit_empty_list, x_scales = x_scales, y_scales = y_scales, class = "scale_ggsurvfit")

--- a/man/scale_ggsurvfit.Rd
+++ b/man/scale_ggsurvfit.Rd
@@ -32,6 +32,17 @@ For example, it's common you'll need to specify the x-axis break points.
 To reset any of the above settings to their ggplot2 default, set the value
 to \code{NULL}, e.g. \code{y_scales = list(limits = NULL)}.
 }
+\details{
+Special case: in the risk table, large numbers (with more than 4 digits) may not
+be shown completely, with some digits truncated outside the plot region.
+To remedy this, consider adjusting the expand size:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{scale_ggsurvfit(x_scales = list(expand = c(0.05, 0)))
+}\if{html}{\out{</div>}}
+
+This can modify the position of numbers in the risk table
+and make them all fit in the plot region. The scale of the \code{expand} argument differs by cases.
+}
 \examples{
 ggsurvfit <-
   survfit2(Surv(time, status) ~ surg, data = df_colon) \%>\%
@@ -44,6 +55,7 @@ ggsurvfit + scale_ggsurvfit()
 # specify additional scales
 ggsurvfit +
   scale_ggsurvfit(x_scales = list(breaks = seq(0, 8, by = 2)))
+#'
 }
 \seealso{
 Visit the \href{https://www.danieldsjoberg.com/ggsurvfit/articles/gallery.html}{gallery} for examples modifying the default figures

--- a/man/scale_ggsurvfit.Rd
+++ b/man/scale_ggsurvfit.Rd
@@ -55,7 +55,6 @@ ggsurvfit + scale_ggsurvfit()
 # specify additional scales
 ggsurvfit +
   scale_ggsurvfit(x_scales = list(breaks = seq(0, 8, by = 2)))
-#'
 }
 \seealso{
 Visit the \href{https://www.danieldsjoberg.com/ggsurvfit/articles/gallery.html}{gallery} for examples modifying the default figures


### PR DESCRIPTION
**What changes are proposed in this pull request?**

Updated the documentation for scale_ggsurvfit.R to address the issue of truncated number in risk table


**If there is an GitHub issue associated with this pull request, please provide link.**

closes https://github.com/pharmaverse/ggsurvfit/issues/216

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark as complete)

- [x] Ensure all package dependencies are installed by running `renv::install()`
- [x] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [x] If a new function was added, function included in `_pkgdown.yml`
- [x] If a bug was fixed, a unit test was added for the bug check
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Overall code coverage remains >99.5%. Review coverage with `withr::with_envvar(list(CI = TRUE), code = devtools::test_coverage())`. Begin in a fresh R session without any packages loaded. 
- [x] R CMD Check runs without errors, warnings, and notes
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# ggsurvfit (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [x] Increment the version number using `usethis::use_version(which = "dev")` 
- [x] Run `usethis::use_spell_check()` again
- [x] Approve Pull Request
- [x] Merge the PR. Please use "Squash and merge".

