### PR TITLE
Error msg survfit.coxphms #222

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggsurvfit (development version)
 
+* Improved error message when `ggcuminc()` is called with `survfit.coxphms` objects. (#222)
+
 * Fixed `add_pvalue()` function to work with all outcomes in `ggcuminc()`, not just the first outcome level. (#239, @samrickman)
 
 * Correcting an argument name partial match in `ggplot2::scale_*(labels)`. (#211, @DanChaltiel)

--- a/R/ggcuminc.R
+++ b/R/ggcuminc.R
@@ -57,6 +57,13 @@ ggcuminc <- function(x, outcome = NULL,
     )
   }
 
+   # Generate an error if the input is a `survfit.coxphms` regression model: ----
+  if (inherits(x, "survfitcoxms")) {
+    cli_abort(
+      "Argument {.arg x} does not support {.cls survfit.coxphms} object."
+    )
+  }
+
   # prep data to be passed to ggplot() -----------------------------------------
   if (inherits(x, "tidycuminc")) {
     df <- tidy_cuminc(x = x)

--- a/R/ggcuminc.R
+++ b/R/ggcuminc.R
@@ -47,22 +47,13 @@
 ggcuminc <- function(x, outcome = NULL,
                      linetype_aes = FALSE,
                      theme = theme_ggsurvfit_default(), ...) {
-  # check inputs ---------------------------------------------------------------
-  if (!inherits(x, c("tidycuminc", "survfitms"))) {
-    cli_abort(
-      c(
-        "!" = "Argument {.code x} must be {.cls tidycuminc}.",
-        "i" = "Create the object with {.code tidycmprsk::cuminc()}."
-      )
-    )
-  }
-
-   # Generate an error if the input is a `survfit.coxphms` regression model: ----
-  if (inherits(x, "survfitcoxms")) {
-    cli_abort(
-      "Argument {.arg x} does not support {.cls survfit.coxphms} object."
-    )
-  }
+# Combined check:
+if (!inherits(x, c("tidycuminc", "survfitms")) || inherits(x, "survfitcoxms")) {
+  cli_abort(
+    c("!" = "Object passed in argument {.arg x} must be class {.cls tidycuminc} or {.cls survfitms}. The {.cls survfitcoxms} class is not supported.",
+      "i" = "Create the cumulative incidence object using {.fun tidycmprsk::cuminc}.")
+  )
+}
 
   # prep data to be passed to ggplot() -----------------------------------------
   if (inherits(x, "tidycuminc")) {

--- a/tests/testthat/test-ggcuminc.R
+++ b/tests/testthat/test-ggcuminc.R
@@ -87,3 +87,29 @@ test_that("ggcuminc() axis label correct with multi-state model ", {
     "Probability in State"
   )
 })
+
+test_that("ggcuminc() throws error with survfit.coxphms objects", {
+  skip_if_not_installed("survival")
+  
+  # Create a Cox model with competing risks data
+  cox_model <- survival::coxph(
+    Surv(ttdeath, death_cr) ~ trt, 
+    data = tidycmprsk::trial
+  )
+  
+  # Create survfit object from Cox model (this creates survfit.coxphms class)
+  survfit_coxphms_obj <- survival::survfit(cox_model)
+  
+  # Test that the specific error message is thrown
+  expect_error(
+    ggcuminc(survfit_coxphms_obj),
+    "Argument.*does not support.*survfit\\.coxphms.*object"
+  )
+  
+  # Testing the exact error message (for more precision)
+  expect_error(
+    ggcuminc(survfit_coxphms_obj),
+    "Argument `x` does not support `survfit.coxphms` object.",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-ggcuminc.R
+++ b/tests/testthat/test-ggcuminc.R
@@ -117,6 +117,6 @@ test_that("ggcuminc() throws error with survfit.coxphms objects", {
   # Test that the specific error message is thrown
   expect_error(
     ggcuminc(survfit_coxphms_obj),
-    "Argument.*does not support.*survfit\\.coxphms.*object"
+    "Object passed in argument.*must be class.*tidycuminc.*or.*survfitms.*survfitcoxms.*not supported"
   )
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**

- Improve error message when user passes survfit.coxphms model. 

**If there is an GitHub issue associated with this pull request, please provide link.**

Closes #222 

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark as complete)

- [ ] Ensure all package dependencies are installed by running `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Overall code coverage remains >99.5%. Review coverage with `withr::with_envvar(list(CI = TRUE), code = devtools::test_coverage())`. Begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# ggsurvfit (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

