### PR TITLE
Adding in patchwork:free functionality

### DIFF
--- a/R/ggsurvfit_align_plots.R
+++ b/R/ggsurvfit_align_plots.R
@@ -1,15 +1,3 @@
-# Internal function to combine plots using patchwork::free() for better alignment
-ggsurvfit_combine_plots <- function(main_plot, 
-                                   risk_table, 
-                                   free_type = "space", 
-                                   free_side = "l",
-                                   heights = c(6, 1)) {
-  
-  patchwork::free(main_plot, type = free_type, side = free_side) / 
-    risk_table + 
-    patchwork::plot_layout(heights = heights)
-}
-
 #' Align Plots
 #'
 #' Function accepts a list of ggplot objects, and aligns each plot to the same
@@ -66,6 +54,7 @@ ggsurvfit_align_plots <- function(pltlist) {
       suppressWarnings(
         ggplot2::ggplot_build(pltlist[[i]])$layout$panel_params[[1]]$y.range
       )
+
     pltlist[[i]] <-
       pltlist[[i]] +
       ggplot2::coord_cartesian(
@@ -74,40 +63,35 @@ ggsurvfit_align_plots <- function(pltlist) {
         expand = FALSE
       )
   }
-  
-  # Use improved patchwork alignment for better results
-  if (length(pltlist) >= 2) {
-    ggsurvfit_combine_plots(
-      main_plot = pltlist[[1]],
-      risk_table = pltlist[[2]],
-      free_type = "space",
-      free_side = "l",
-      heights = c(6, 1)
-    )
-  }
-  
+
   # turn plots into grobs and determine number of columns
   plots_grobs <- lapply(pltlist, function(x) suppressWarnings(ggplot2::ggplotGrob(x)))
   ncols <- lapply(plots_grobs, function(x) dim(x)[[2]])
   maxcols <- max(unlist(ncols))
+
   # Function to add more columns to compensate for eg missing legend
   .addcols <- function(x) {
     diffcols <- maxcols - dim(x)[[2]]
+
     if (diffcols > 0) {
       for (i in seq(1:diffcols)) {
         x <- gtable::gtable_add_cols(x, widths = grid::unit(1, "null"), pos = 8)
       }
     }
+
     x
   }
+
   ### TableGrob 1 has 11 columns while the others have only 9 because lacking legend+spacer
   ## => add two columns and then resize
   plots_grobs_xcols <- lapply(plots_grobs, .addcols)
+
   ### assign max length to ensure alignment
   max_width <- do.call(grid::unit.pmax, lapply(plots_grobs_xcols, "[[", "widths"))
   for (i in seq(1, length(plots_grobs_xcols))) {
     plots_grobs_xcols[[i]]$widths <- max_width
   }
+
   xcol_widths <- grid::convertWidth(
     plots_grobs_xcols[[1]]$widths,
     unitTo = "cm",
@@ -119,6 +103,8 @@ ggsurvfit_align_plots <- function(pltlist) {
     valueOnly = FALSE
   )
   x <- xcol_widths[[4]] - grob_widths[[4]]
+
   plots_grobs_xcols[[1]]$grobs[[13]]$children[[1]]$x <- grid::unit(x, "cm")
+
   plots_grobs_xcols
 }

--- a/R/utils-add_risktable.R
+++ b/R/utils-add_risktable.R
@@ -53,7 +53,7 @@
   if (isTRUE(combine_plots)) {
     # Apply patchwork::free() to main plot to solve alignment issues
     
-    main_plot_free <- patchwork::free(x, type = "label", side = "l")
+    main_plot_free <- patchwork::free(x, type = "space", side = "l")
     
     # Combine using patchwork directly 
     if (length(gg_risktable_list) == 1) {
@@ -81,30 +81,14 @@
   }
 
   # FALLBACK: Use original method when combine_plots = FALSE 
-  # ensures backward compatibility
+  # Ensures backward compatibility - return grobs directly
   
-  # use existing ggsurvfit_align_plots function
   plot_list <- c(list(x), gg_risktable_list)
-  lst_plots <- ggsurvfit_align_plots(plot_list)
+  lst_plots <- ggsurvfit_align_plots(plot_list)  # Returns grobs
   
-  # apply heights using patchwork on the grobs
-  n_plots <- length(lst_plots)
-  if (n_plots == 1) {
-    return(lst_plots[[1]])
-  }
-  
-  # calculate heights for the grob layout
-  n_risktables <- n_plots - 1
-  risktable_height_each <- risktable_height / n_risktables
-  
-  # combine grobs with heights using patchwork::wrap_plots
-  heights <- c(1 - risktable_height, rep(risktable_height_each, n_risktables))
-  
-  patchwork::wrap_plots(
-    plotlist = lst_plots,
-    ncol = 1,
-    heights = heights
-  )
+  # Return grobs as-is for backward compatibility
+  # Users who set combine_plots = FALSE expect separate grob objects
+  return(lst_plots)
 }
 
 .calculate_risktable_height <- function(risktable_height, risktable_group, risktable_stats, df_times) {

--- a/tests/testthat/test-add_risktable.R
+++ b/tests/testthat/test-add_risktable.R
@@ -336,12 +336,12 @@ test_that("add_risktable() works with ggsurvfit() `start.time` and negative time
 
 
 test_that("add_risktable() works with multiple survival endpoints (Issue #212)", {
-  
+
   os_data <- df_lung %>% dplyr::mutate(PARAM = "Overall Survival")
   pfs_data <- df_lung %>% dplyr::mutate(time = time * 0.7, PARAM = "Progression-Free Survival")
   combined_data <- dplyr::bind_rows(os_data, pfs_data)
-  
- 
+
+
   expect_error(
     p <- survfit2(Surv(time, status) ~ PARAM, data = combined_data) %>%
       ggsurvfit() + add_risktable(),
@@ -350,3 +350,122 @@ test_that("add_risktable() works with multiple survival endpoints (Issue #212)",
   expect_error(print(p), NA)
 })
 
+
+test_that("add_risktable() handles large numbers and long labels without overlapping (Issue #230)", {
+
+  # Large patient cohort with descriptive strata labels
+  set.seed(123)  # For reproducible results
+
+  large_cohort_data <- data.frame(
+    time = c(
+      # Extended Time Since Surgery group - longer survival times
+      rexp(800, rate = 0.15),
+      # Limited Time Since Surgery group - shorter survival times
+      rexp(1200, rate = 0.25)
+    ),
+    status = c(
+      rbinom(800, 1, 0.6),   # 60% event rate for extended group
+      rbinom(1200, 1, 0.75)  # 75% event rate for limited group
+    ),
+    surgery_timing = factor(c(
+      rep("Extended Time Since Surgery", 800),
+      rep("Limited Time Since Surgery", 1200)
+    ))
+  )
+
+  # Create survfit object with large numbers
+  sf_large_cohort <- survfit2(Surv(time, status) ~ surgery_timing, data = large_cohort_data)
+
+  # Large numbers at time 0: ~800 and ~1200 patients at risk
+  expect_error(
+    p_issue_230 <- sf_large_cohort %>%
+      ggsurvfit() +
+      add_risktable(risktable_stats = "n.risk"),
+    NA
+  )
+
+  expect_error(print(p_issue_230), NA)
+
+  # Test with the format from the user's image: "At risk (censored)"
+  expect_error(
+    p_issue_230_with_censored <- sf_large_cohort %>%
+      ggsurvfit() +
+      add_risktable(
+        risktable_stats = "{n.risk} ({cum.censor})",
+        stats_label = "At risk (censored)"
+      ),
+    NA
+  )
+
+  expect_error(print(p_issue_230_with_censored), NA)
+
+  # Test that the plot actually has large numbers at time 0
+  risk_data <- sf_large_cohort %>% tidy_survfit(times = 0)
+  expect_true(any(risk_data$n.risk >= 500),
+              info = "Should have large patient numbers at baseline")
+
+  # Test with even longer strata names that would definitely cause issues
+  very_long_labels_data <- large_cohort_data %>%
+    dplyr::mutate(
+      surgery_timing = factor(
+        surgery_timing,
+        levels = c("Extended Time Since Surgery", "Limited Time Since Surgery"),
+        labels = c(
+          "Extended Time Between Surgery and Treatment Initiation",
+          "Limited Time Between Surgery and Treatment Initiation"
+        )
+      )
+    )
+
+  sf_very_long <- survfit2(Surv(time, status) ~ surgery_timing, data = very_long_labels_data)
+
+  expect_error(
+    p_very_long_labels <- sf_very_long %>%
+      ggsurvfit() +
+      add_risktable(risktable_stats = "n.risk"),
+    NA
+  )
+
+  expect_error(print(p_very_long_labels), NA)
+
+  # Skip visual tests on CI but include them for local testing
+  skip_on_ci()
+  vdiffr::expect_doppelganger("issue-230-large-numbers", p_issue_230)
+  vdiffr::expect_doppelganger("issue-230-with-censored", p_issue_230_with_censored)
+  vdiffr::expect_doppelganger("very-long-labels", p_very_long_labels)
+})
+
+# Additional test specifically for the overlapping issue
+test_that("add_risktable() prevents text overlapping with patchwork::free()", {
+  # Create a scenario guaranteed to cause overlapping without the fix
+  overlap_data <- data.frame(
+    time = rexp(2000, 0.1),  # Very large cohort
+    status = rbinom(2000, 1, 0.5),
+    group = factor(c(
+      rep("Group with extremely long descriptive name that would cause overlap", 1000),
+      rep("Another group with very long name causing alignment issues", 1000)
+    ))
+  )
+
+  sf_overlap <- survfit2(Surv(time, status) ~ group, data = overlap_data)
+
+  # This would definitely cause overlapping without patchwork::free()
+  expect_error(
+    p_overlap_test <- sf_overlap %>%
+      ggsurvfit() +
+      add_risktable(risktable_stats = "n.risk") +
+      # Force narrow margins to test the alignment fix
+      theme(plot.margin = margin(0.1, 0.1, 0.1, 0.1, "cm")),
+    NA
+  )
+
+  expect_error(print(p_overlap_test), NA)
+
+  # Test that numbers at time 0 are indeed large (>1000)
+  baseline_risk <- sf_overlap %>% tidy_survfit(times = 0)
+  expect_true(all(baseline_risk$n.risk >= 900),
+              info = "All groups should have large patient numbers")
+
+  skip_on_ci()
+  vdiffr::expect_doppelganger("overlap-prevention-test", p_overlap_test)
+})


### PR DESCRIPTION

**What changes are proposed in this pull request?**
- Adding in patchwork:free() to better align risktables with plots, especially when x-axes labels are very long.


**If there is an GitHub issue associated with this pull request, please provide link.**
Closes #230 

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark as complete)

- [ ] Ensure all package dependencies are installed by running `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Overall code coverage remains >99.5%. Review coverage with `withr::with_envvar(list(CI = TRUE), code = devtools::test_coverage())`. Begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# ggsurvfit (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

