### PR TITLE
Closes #271 surv_cnsr: allow CSNR > 1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggsurvfit
 Title: Flexible Time-to-Event Figures
-Version: 1.2.0.9000
+Version: 1.2.0.9001
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggsurvfit (development version)
 
+* `Surv_CNSR()` updated to accept values `>= 1` as censoring values (according
+to CDISC recommendation). (#271)
+
 # ggsurvfit 1.2.0
 
 * Updates to account for changes in ggplot2 v4.0.0. (#241)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # ggsurvfit (development version)
 
 * `Surv_CNSR()` updated to accept values `>= 1` as censoring values (according
-to CDISC recommendation). (#271)
+to CDISC recommendation). (#271, @bundfussr)
 
 # ggsurvfit 1.2.0
 

--- a/R/Surv_CNSR.R
+++ b/R/Surv_CNSR.R
@@ -12,7 +12,7 @@
 #' [survival](https://cran.r-project.org/package=survival) package.
 #'
 #' The `AVAL` and `CNSR` arguments are passed to
-#' `survival::Surv(time = AVAL, event = 1 - CNSR, type = "right", origin = 0)`.
+#' `survival::Surv(time = AVAL, event = CNSR == 0, type = "right", origin = 0)`.
 #'
 #' @section Details:
 #'
@@ -29,11 +29,11 @@
 #'
 #' The CDISC ADaM ADTTE data model adopts a different coding convention for
 #' the event/status indicator. Using this convention, the event/status variable
-#' is named `'CNSR'` and uses the following coding: `censor = 1`, `status/event = 0`.
+#' is named `'CNSR'` and uses the following coding: `censor >= 1`, `status/event = 0`.
 #'
 #' @param AVAL The follow-up time. The follow-up time is assumed to originate from zero.
 #' When no argument is passed, the default value is a column/vector named `AVAL`.
-#' @param CNSR The censoring indicator where `1=censored` and `0=death/event`.
+#' @param CNSR The censoring indicator where `>=1=censored` and `0=death/event`.
 #' When no argument is passed, the default value is a column/vector named `CNSR`.
 #'
 #' @return Object of class 'Surv'
@@ -68,11 +68,8 @@ Surv_CNSR <- function(AVAL, CNSR) {
     stop("Expecting arguments 'AVAL' and 'CNSR' to be numeric.")
   }
 
-  if (stats::na.omit(CNSR) %>% setdiff(c(0, 1)) %>%
-      {
-        !rlang::is_empty(.)
-      }) {
-    stop("Expecting 'CNSR' argument to be binary with values `0/1`.")
+  if (any(stats::na.omit(CNSR) < 0)) {
+    stop("Expecting 'CNSR' argument to be non-negative (>=0).")
   }
 
   if (any(AVAL < 0)) {
@@ -80,5 +77,5 @@ Surv_CNSR <- function(AVAL, CNSR) {
   }
 
   # pass args to `survival::Surv()` --------------------------------------------
-  survival::Surv(time = AVAL, event = 1 - CNSR, type = "right", origin = 0)
+  survival::Surv(time = AVAL, event = CNSR == 0, type = "right", origin = 0)
 }

--- a/R/Surv_CNSR.R
+++ b/R/Surv_CNSR.R
@@ -68,8 +68,8 @@ Surv_CNSR <- function(AVAL, CNSR) {
     stop("Expecting arguments 'AVAL' and 'CNSR' to be numeric.")
   }
 
-  if (any(stats::na.omit(CNSR) < 0)) {
-    stop("Expecting 'CNSR' argument to be non-negative (>=0).")
+  if (any(!rlang::is_integerish(CNSR)) || any(stats::na.omit(CNSR) < 0)) {
+    stop("Expecting 'CNSR' argument to be non-negative integer (>=0).")
   }
 
   if (any(AVAL < 0)) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -100,7 +100,7 @@ The package also includes gems for those using the [CDISC ADaM ADTTE v1.0](https
 
 If columns `"PARAM"` or `"PARAMCD"` are present in the data frame passed to `survfit2()`, their values will be used to construct default labels in the `ggsurvfit()` figure. 
 
-The event indicator in ADTTE data sets is named `"CNSR"` and is coded in the opposite way the survival package expects outcomes---`1 = 'censored'` and `0 = 'event'`.
+The event indicator in ADTTE data sets is named `"CNSR"` and is coded in the opposite way the survival package expects outcomes---`>=1 = 'censored'` and `0 = 'event'`.
 This difference creates an opportunity for errors to be introduced in an analysis.
 The **ggsurvfit** package exports a function called `Surv_CNSR()` to resolve this concern.
 The function creates a survival object (e.g. `survival::Surv()`) that uses CDISC ADaM ADTTE coding conventions as the default values.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ p +
   )
 ```
 
-<img src="man/figures/README-unnamed-chunk-2-1.png" width="100%" />
+<img src="man/figures/README-unnamed-chunk-2-1.png" alt="" width="100%" />
 
 ## `survfit2()` vs `survfit()`
 
@@ -120,14 +120,14 @@ to `survfit2()`, their values will be used to construct default labels
 in the `ggsurvfit()` figure.
 
 The event indicator in ADTTE data sets is named `"CNSR"` and is coded in
-the opposite way the survival package expects outcomes—`1 = 'censored'`
-and `0 = 'event'`. This difference creates an opportunity for errors to
-be introduced in an analysis. The **ggsurvfit** package exports a
-function called `Surv_CNSR()` to resolve this concern. The function
-creates a survival object (e.g. `survival::Surv()`) that uses CDISC ADaM
-ADTTE coding conventions as the default values. The function can be used
-in **ggsurvfit** as well as any other package that uses
-`survival::Surv()`.
+the opposite way the survival package expects
+outcomes—`>=1 = 'censored'` and `0 = 'event'`. This difference creates
+an opportunity for errors to be introduced in an analysis. The
+**ggsurvfit** package exports a function called `Surv_CNSR()` to resolve
+this concern. The function creates a survival object
+(e.g. `survival::Surv()`) that uses CDISC ADaM ADTTE coding conventions
+as the default values. The function can be used in **ggsurvfit** as well
+as any other package that uses `survival::Surv()`.
 
 ``` r
 survfit(Surv_CNSR() ~ 1, adtte)
@@ -139,4 +139,4 @@ survfit(Surv_CNSR() ~ 1, adtte)
 
 ## Related Packages
 
-<img src="man/figures/README-gt-related-pkgs.png" width="100%" />
+<img src="man/figures/README-gt-related-pkgs.png" alt="" width="100%" />

--- a/man/Surv_CNSR.Rd
+++ b/man/Surv_CNSR.Rd
@@ -10,7 +10,7 @@ Surv_CNSR(AVAL, CNSR)
 \item{AVAL}{The follow-up time. The follow-up time is assumed to originate from zero.
 When no argument is passed, the default value is a column/vector named \code{AVAL}.}
 
-\item{CNSR}{The censoring indicator where \code{1=censored} and \code{0=death/event}.
+\item{CNSR}{The censoring indicator where \verb{>=1=censored} and \code{0=death/event}.
 When no argument is passed, the default value is a column/vector named \code{CNSR}.}
 }
 \value{
@@ -27,7 +27,7 @@ status/event variable convention used in the
 \href{https://cran.r-project.org/package=survival}{survival} package.
 
 The \code{AVAL} and \code{CNSR} arguments are passed to
-\code{survival::Surv(time = AVAL, event = 1 - CNSR, type = "right", origin = 0)}.
+\code{survival::Surv(time = AVAL, event = CNSR == 0, type = "right", origin = 0)}.
 }
 \section{Details}{
 
@@ -45,7 +45,7 @@ all subjects are assumed to have an event.
 
 The CDISC ADaM ADTTE data model adopts a different coding convention for
 the event/status indicator. Using this convention, the event/status variable
-is named \code{'CNSR'} and uses the following coding: \code{censor = 1}, \code{status/event = 0}.
+is named \code{'CNSR'} and uses the following coding: \code{censor >= 1}, \code{status/event = 0}.
 }
 
 \examples{

--- a/tests/testthat/test-Surv_CNSR.R
+++ b/tests/testthat/test-Surv_CNSR.R
@@ -23,16 +23,16 @@ test_that("The function is compatible with the survival package", {
 test_that("The results of the estimation match between Surv_CNSR and Surv with inverted censoring", {
   expect_equal(
     with(adtte, Surv_CNSR()),
-    with(adtte, Surv(AVAL, 1 - CNSR))
+    with(adtte, Surv(AVAL, CNSR == 0))
   )
 
   km1 <- survfit2(formula = Surv_CNSR() ~ 1, data = adtte)
-  km2 <- survfit2(formula = Surv(AVAL, 1 - CNSR) ~ 1, data = adtte)
+  km2 <- survfit2(formula = Surv(AVAL, CNSR == 0) ~ 1, data = adtte)
   km1$call <- km2$call <- km1$.Environment <- km2$.Environment <- NULL
   expect_equal(km1, km2)
 
   km1 <- survfit2(formula = Surv_CNSR() ~ STR01, data = adtte)
-  km2 <- survfit2(formula = Surv(AVAL, 1 - CNSR) ~ STR01, data = adtte)
+  km2 <- survfit2(formula = Surv(AVAL, CNSR == 0) ~ STR01, data = adtte)
   km1$call <- km2$call <- km1$.Environment <- km2$.Environment <- NULL
   expect_equal(km1, km2)
 })
@@ -74,6 +74,9 @@ test_that("An error when the column name specified through CNSR in the environme
   expect_error(survfit(Surv_CDISC(AVAL = time) ~ 1, data = survival::lung %>% dplyr::mutate(CNSR = as.character(status))))
 })
 
-test_that("An error when the column name specified through CNSR is not coded as 0/1", {
-  expect_error(survfit(Surv_CNSR(time, status) ~ 1, data = survival::lung))
+test_that("An error when the column name specified through CNSR < 0", {
+  expect_error(survfit(
+    Surv_CNSR(time, status) ~ 1,
+    data = survival::lung %>% dplyr::mutate(status = status - 2)
+  ))
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**

Allow `CNSR > 1` in `Surv_CNSR()` to be in line with CDISC recommendation.

**If there is an GitHub issue associated with this pull request, please provide link.**

https://github.com/pharmaverse/ggsurvfit/issues/271

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark as complete)

- [ ] Ensure all package dependencies are installed by running `renv::install()`
- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Overall code coverage remains >99.5%. Review coverage with `withr::with_envvar(list(CI = TRUE), code = devtools::test_coverage())`. Begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# ggsurvfit (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

