### PR TITLE
Fix add_pvalue() matching Gray-test p-value to plotted outcome by name (#277)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,100 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in the **ggsurvfit** repository. Human contributors
+should also read [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md), which this file
+summarizes and does not replace.
+
+## What this package is
+
+**ggsurvfit** is an R package (a ggplot2 extension) for building publication-ready
+time-to-event / survival figures. Its design principle: every add-on is a *real* ggplot2
+layer, so package functions compose with ordinary ggplot2 code via `+`.
+
+- **Kaplan–Meier:** `survfit2()` wraps `survival::survfit()` (keeping the call/environment so
+  labels and formulas can be recovered), then `ggsurvfit()` draws it.
+- **Competing risks:** `tidycmprsk::cuminc()` fits are drawn with `ggcuminc()`.
+- **Modifiers:** `add_confidence_interval()`, `add_risktable()`, `add_censor_mark()`,
+  `add_quantile()`, `add_pvalue()`, `add_legend_title()`, `scale_ggsurvfit()`, etc. Each is
+  added to a plot with `+`.
+
+## Architecture conventions
+
+- **Add-on functions return layer objects; the real work happens in an `ggplot_add.*` S3
+  method.** Pattern (see [`R/add_pvalue.R`](R/add_pvalue.R)): the exported constructor stashes
+  arguments as `attr()`s on a small classed object; a `ggplot_add.<class>()` method (registered
+  via `#' @export`) reads those attributes and modifies the plot when `+` is evaluated. Follow
+  this pattern for any new `add_*()` function rather than mutating the plot eagerly.
+- **Data flows through `tidy_survfit()` / `tidy_cuminc()`**, which normalize `survfit`/`cuminc`
+  objects into tidy data frames with publication-friendly strata labels. Prefer reusing these
+  over re-parsing model objects.
+- **Reach into a built plot with `ggplot2::ggplot_build(p)`** when a function needs the plotted
+  data (e.g. which outcome/strata are on screen). Suppress expected warnings with
+  `suppressWarnings()` as the existing code does.
+- Small internal helpers live in [`R/utils.R`](R/utils.R) and
+  [`R/utils-add_risktable.R`](R/utils-add_risktable.R); internal helpers are named with a
+  leading dot (e.g. `.extract_data_from_survfit()`) or are plainly un-exported. Check here
+  before writing a new helper.
+
+## Dependencies
+
+- **Imports** (usable freely, no `::` needed once imported): broom, cli, dplyr, ggplot2 (>=
+  4.0.0), glue, gtable, patchwork, rlang, survival, tidyr.
+- **Suggests** (competing-risks + testing/tooling): tidycmprsk, testthat, vdiffr, scales,
+  withr, knitr, rmarkdown, covr, spelling. **Always guard/qualify Suggests** — reference them
+  as `tidycmprsk::cuminc()` and, in code paths that require them, call
+  `rlang::check_installed("tidycmprsk")` (see [`R/tidy_cuminc.R`](R/tidy_cuminc.R)).
+- The magrittr pipe `%>%` and the native `|>` both appear; match the surrounding file.
+
+## Style and messaging
+
+- Follow the tidyverse [style guide](https://style.tidyverse.org). You may run
+  [`styler`](https://styler.r-lib.org), but **do not restyle code unrelated to your change.**
+- **Errors/warnings/messages** use cli, imported bare as `cli_abort()`, `cli_warn()`,
+  `cli_inform()` (see the `@importFrom cli` line in
+  [`R/ggsurvfit-package.R`](R/ggsurvfit-package.R)). Convention: state the problem first, then
+  an optional `"i"` hint:
+  ```r
+  cli_abort(c("!" = "There was an error.",
+              "i" = "A helpful message to resolve it."))
+  ```
+- **Documentation is roxygen2 with markdown** (`Roxygen: list(markdown = TRUE)`). Edit the
+  roxygen comments in `R/*.R`, never the generated `man/*.Rd` or `NAMESPACE` by hand — run
+  `devtools::document()` to regenerate them.
+
+## Testing
+
+- testthat edition 3 (`Config/testthat/edition: 3`); tests live in `tests/testthat/` as
+  `test-<topic>.R` mirroring the `R/` file names.
+- **Test plot structure by building first:** `ggplot2::ggplot_build(p)` (or the package's
+  `ggsurvfit_build()`), then assert on the returned data — don't eyeball the object. Assert the
+  *correct* value, not merely that output is non-empty (a weak `grepl("p", ...)` check let bug
+  #277 slip through).
+- **Image regression tests use vdiffr** (`vdiffr::expect_doppelganger(...)`). These are skipped
+  when vdiffr is absent and are typically gated behind `skip_on_ci()` / `skip_on_cran()`.
+- New features and bug fixes **must** include a test. For bug fixes, write a test that fails on
+  the old code and passes on the fix.
+
+## Developer workflow (run from the package root)
+
+```r
+devtools::load_all()        # load current source
+devtools::document()        # regenerate man/ and NAMESPACE after roxygen changes
+devtools::test()            # run all tests  (or: testthat::test_file("tests/testthat/test-<x>.R"))
+devtools::check()           # full R CMD check — should pass clean before a PR
+devtools::install_dev_deps()# first-time setup
+```
+
+If `Rscript`/`R` is not on `PATH` (common on Windows), invoke it by full path, e.g.
+`"C:\Program Files\R\bin\Rscript.bat"`.
+
+## Change checklist (before opening a PR)
+
+1. Code follows tidyverse style; only your lines are restyled.
+2. roxygen updated and `devtools::document()` run (man/ + NAMESPACE regenerated).
+3. Tests added/updated; `devtools::test()` green.
+4. `devtools::check()` clean.
+5. **User-facing changes get a `NEWS.md` bullet** at the top (just under the first header),
+   in tidyverse [NEWS style](https://style.tidyverse.org/news.html), referencing the issue/PR
+   number (e.g. `(#277)`).
+6. PR title briefly describes the change; PR body contains `Fixes #<issue>`.
+```

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggsurvfit
 Title: Flexible Time-to-Event Figures
-Version: 1.2.0.9001
+Version: 1.2.0.9002
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggsurvfit (development version)
 
+* Fixed `add_pvalue()` reporting the Gray-test p-value for the wrong competing event when the outcome ordering from `tidycmprsk::tidy()` and `tidycmprsk::glance()` differed. The p-value is now matched to the plotted outcome by name. (#277)
+
 * Fixed `add_quantile()` to use the midpoint of plateau segments when the curve plotted is flat at the requested quantile, consistent with results from `survival::quantile.survfit()` (#270)
 
 * `Surv_CNSR()` updated to accept values `>= 1` as censoring values (according

--- a/R/add_pvalue.R
+++ b/R/add_pvalue.R
@@ -99,10 +99,6 @@ update_add_pvalue <- function(p, add_pvalue_empty_list) {
   # check only a single outcome is selected
   if (inherits(survfit, "tidycuminc")) {
     outcomes_chosen <- suppressWarnings(ggplot2::ggplot_build(p))$plot$data$outcome |> unique()
-    outcomes_all <- tidycmprsk::tidy(survfit) |>
-      dplyr::pull("outcome") |>
-      unique()
-    outcomes_chosen_position <- which(outcomes_all %in% outcomes_chosen)
     if (length(outcomes_chosen) > 1L) {
       cli_abort(
         c("{.fun add_pvalue} supports reporting a single competing event
@@ -121,9 +117,19 @@ update_add_pvalue <- function(p, add_pvalue_empty_list) {
                           rho = rho)
   }
   else if (inherits(survfit, "tidycuminc")) {
+    glance_df <- tidycmprsk::glance(survfit)
+    # `tidy()` and `glance()` may order outcomes differently, so match the chosen
+    # outcome to the `glance()` p-value column by name rather than by position (#277)
+    n_outcomes <- sum(grepl("^outcome_[0-9]+$", names(glance_df)))
+    outcome_position <-
+      which(vapply(
+        seq_len(n_outcomes),
+        function(i) identical(glance_df[[paste0("outcome_", i)]], outcomes_chosen),
+        logical(1L)
+      ))
     p.value <-
-      tidycmprsk::glance(survfit) %>%
-      dplyr::pull(paste0("p.value_", outcomes_chosen_position)) %>%
+      glance_df %>%
+      dplyr::pull(paste0("p.value_", outcome_position)) %>%
       pvalue_fun() %>%
       {dplyr::case_when(
         !prepend_p ~ .,

--- a/tests/testthat/test-add_pvalue.R
+++ b/tests/testthat/test-add_pvalue.R
@@ -73,6 +73,63 @@ test_that("add_pvalue() works", {
 })
 
 
+test_that("add_pvalue() matches the p-value to the plotted outcome by name (#277)", {
+  # relevel `death_cr` so the factor ordering (used by `tidy()`) differs from the
+  # failcode ordering (used by `glance()` p.value_* columns)
+  trial_relevel <- tidycmprsk::trial
+  trial_relevel$death_cr <-
+    factor(
+      as.character(trial_relevel$death_cr),
+      levels = c("censor", "death other causes", "death from cancer")
+    )
+
+  cuminc_fit <- tidycmprsk::cuminc(Surv(ttdeath, death_cr) ~ trt, trial_relevel)
+  glance_df <- tidycmprsk::glance(cuminc_fit)
+
+  # expected p-values keyed by outcome name, matched from glance() by name
+  n_outcomes <- sum(grepl("^outcome_[0-9]+$", names(glance_df)))
+  expected_p <- vapply(
+    seq_len(n_outcomes),
+    function(i) glance_df[[paste0("p.value_", i)]],
+    numeric(1L)
+  )
+  names(expected_p) <- vapply(
+    seq_len(n_outcomes),
+    function(i) glance_df[[paste0("outcome_", i)]],
+    character(1L)
+  )
+
+  # sanity check: tidy() and glance() orderings actually differ for this fit,
+  # otherwise the regression test would not exercise the bug
+  expect_false(
+    identical(
+      unique(tidycmprsk::tidy(cuminc_fit)[["outcome"]]),
+      unname(names(expected_p))
+    )
+  )
+
+  reported_p <- vapply(
+    names(expected_p),
+    function(outcome) {
+      caption <-
+        (ggcuminc(cuminc_fit, outcome = outcome) +
+           add_pvalue(pvalue_fun = function(x) as.character(x), prepend_p = FALSE))$labels$caption
+      as.numeric(caption)
+    },
+    numeric(1L)
+  )
+
+  # each plotted outcome reports its own Gray-test p-value
+  expect_equal(reported_p, expected_p)
+
+  # and the two outcomes' p-values are not swapped
+  expect_false(isTRUE(all.equal(
+    reported_p[["death from cancer"]],
+    expected_p[["death other causes"]]
+  )))
+})
+
+
 test_that("add_pvalue() throws proper errors", {
   expect_error(
     (survfit2(Surv(time, status) ~ surg, df_colon) %>%


### PR DESCRIPTION
## What

Fixes #277 — for competing-risks fits, `add_pvalue()` could report the Gray-test p-value for the **wrong** competing event.

## Why

In `update_add_pvalue()` (`R/add_pvalue.R`), the outcome position was derived from the row order of `tidycmprsk::tidy(survfit)$outcome` and then reused to index the wide `p.value_*` columns produced by `tidycmprsk::glance()`. Those two orderings are independent (tidy orders by first appearance of the label; glance numbers columns by failcode), so when they diverged the reported p-value belonged to a different outcome than the one plotted.

Reproduced by re-leveling `death_cr` so the factor order differs from the failcode order: choosing `"death from cancer"` (tidy position 1) wrongly pulled `p.value_1` (0.766, belonging to `"death other causes"`) instead of the correct `p.value_2` (0.159).

## How

The chosen outcome is now matched **by name** against `glance()`'s own `outcome_*` columns, and the paired `p.value_*` column is pulled. This removes any dependency on `tidy()` ordering. The now-unused `tidycmprsk::tidy()` call and position calculation in the single-outcome-check block were removed; the multi-outcome abort is unchanged.

## Tests

- Added a regression test in `tests/testthat/test-add_pvalue.R` using a fit where `tidy()` and `glance()` orderings differ. It asserts each plotted outcome reports its own p-value, that the two outcomes' values are not swapped, and includes a sanity check that the orderings genuinely differ (so the test actually exercises the bug).
- Existing competing-risks tests only checked that *some* p-value string was present, so the bug previously passed them.

## Reviewer notes

- The fix assumes the plotted outcome label matches a `glance()` `outcome_*` value exactly; the existing single-outcome guard and `ggcuminc()` outcome validation keep the no-match path unreachable in normal use.
- `NEWS.md` updated with a bullet under the development version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)